### PR TITLE
Add application trigger

### DIFF
--- a/Petrroll.Helpers/Petrroll.Helpers.csproj
+++ b/Petrroll.Helpers/Petrroll.Helpers.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Petrroll.Helpers</RootNamespace>
     <AssemblyName>Petrroll.Helpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PowerSwitcher.TrayApp/App.config
+++ b/PowerSwitcher.TrayApp/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
+++ b/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
@@ -14,6 +14,10 @@ namespace PowerSwitcher.TrayApp.Configuration
         public bool AutomaticOnACSwitch { get; set; } = false;
         public Guid AutomaticPlanGuidOnAC { get; set; } = new Guid("8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c");
         public Guid AutomaticPlanGuidOffAC { get; set; } = new Guid("a1841308-3541-4fab-bc81-f71556f20b4a");
+        public Guid AutomaticPlanGuidOnApp { get; set; } = new Guid("8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c");
+        public Guid AutomaticPlanGuidOffApp { get; set; } = new Guid("a1841308-3541-4fab-bc81-f71556f20b4a");
+
+        public string AutomaticAppSwitchApp { get; set; } = "";
 
         //TODO: Fix so that it can be changed during runtime
         public Key ShowOnShortcutKey { get; set; } = Key.L;

--- a/PowerSwitcher.TrayApp/PowerSwitcher.TrayApp.csproj
+++ b/PowerSwitcher.TrayApp/PowerSwitcher.TrayApp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PowerSwitcher.TrayApp</RootNamespace>
     <AssemblyName>PowerSwitcher.TrayApp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -28,6 +28,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -65,9 +66,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/PowerSwitcher.TrayApp/Properties/Resources.Designer.cs
+++ b/PowerSwitcher.TrayApp/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PowerSwitcher.TrayApp.Properties
-{
-
-
+namespace PowerSwitcher.TrayApp.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace PowerSwitcher.TrayApp.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PowerSwitcher.TrayApp.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/PowerSwitcher.TrayApp/Properties/Settings.Designer.cs
+++ b/PowerSwitcher.TrayApp/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PowerSwitcher.TrayApp.Properties
-{
-
-
+namespace PowerSwitcher.TrayApp.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace PowerSwitcher.TrayApp.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AppStrings {
@@ -75,6 +75,15 @@ namespace PowerSwitcher.TrayApp.Resources {
         internal static string AboutAppURL {
             get {
                 return ResourceManager.GetString("AboutAppURL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Application trigger.
+        /// </summary>
+        internal static string ApplicationName {
+            get {
+                return ResourceManager.GetString("ApplicationName", resourceCulture);
             }
         }
         
@@ -142,11 +151,29 @@ namespace PowerSwitcher.TrayApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Schema to switch to when application exits.
+        /// </summary>
+        internal static string SchemaToSwitchOffApp {
+            get {
+                return ResourceManager.GetString("SchemaToSwitchOffApp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Schema to switch to on AC.
         /// </summary>
         internal static string SchemaToSwitchOnAc {
             get {
                 return ResourceManager.GetString("SchemaToSwitchOnAc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Schema to switch to when application starts.
+        /// </summary>
+        internal static string SchemaToSwitchOnApp {
+            get {
+                return ResourceManager.GetString("SchemaToSwitchOnApp", resourceCulture);
             }
         }
         

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.resx
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.resx
@@ -123,6 +123,9 @@
   <data name="AboutAppURL" xml:space="preserve">
     <value>http://github.com/Petrroll/PowerSwitcher</value>
   </data>
+  <data name="ApplicationName" xml:space="preserve">
+    <value>Application trigger</value>
+  </data>
   <data name="AppName" xml:space="preserve">
     <value>PowerPlanSwitcher</value>
   </data>
@@ -144,8 +147,14 @@
   <data name="SchemaToSwitchOffAc" xml:space="preserve">
     <value>Schema to switch to off AC</value>
   </data>
+  <data name="SchemaToSwitchOffApp" xml:space="preserve">
+    <value>Schema to switch to when application exits</value>
+  </data>
   <data name="SchemaToSwitchOnAc" xml:space="preserve">
     <value>Schema to switch to on AC</value>
+  </data>
+  <data name="SchemaToSwitchOnApp" xml:space="preserve">
+    <value>Schema to switch to when application starts</value>
   </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>

--- a/PowerSwitcher.TrayApp/app.manifest
+++ b/PowerSwitcher.TrayApp/app.manifest
@@ -16,7 +16,7 @@
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
-        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/PowerSwitcher/PowerSwitcher.csproj
+++ b/PowerSwitcher/PowerSwitcher.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PowerSwitcher</RootNamespace>
     <AssemblyName>PowerSwitcher</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This pull requests adds the functionality to switch power plans when an application starts or stops.

New configuration items have been added for:
- Application process name (e.g. 'notepad.exe')
- Power plan to switch to at application start
- Power plan to switch to at application exit

Note that this functionality requires that the app be given administrator privileges.