### PR TITLE
Hotkey to cycle to the next power schema

### DIFF
--- a/Petrroll.Helpers/ObservableCollectionWhereShim.cs
+++ b/Petrroll.Helpers/ObservableCollectionWhereShim.cs
@@ -24,7 +24,7 @@ namespace Petrroll.Helpers
 
     public class ObservableCollectionWhereSwitchableShim<C, T> : ObservableCollectionWhereShim<C, T>, IEnumerable<T> where C : INotifyCollectionChanged, ICollection<T> where T : INotifyPropertyChanged
     {
-        protected IEnumerable<T> currentlySwichtedCollection => (FilterOn) ? filteredCollection : BaseCollection;
+        protected IEnumerable<T> currentlySwitchedCollection => (FilterOn) ? filteredCollection : BaseCollection;
 
         #region Constructor
         public ObservableCollectionWhereSwitchableShim(C baseCollection, Func<T, bool> predicate, bool filterOn) : base(baseCollection, predicate)
@@ -96,12 +96,12 @@ namespace Petrroll.Helpers
         #endregion
 
         #region OtherMethods
-        public override int Count => currentlySwichtedCollection.Count();
-        public override bool Contains(T item) => currentlySwichtedCollection.Contains(item);
-        public override void CopyTo(T[] array, int arrayIndex) => currentlySwichtedCollection.ToList().CopyTo(array, arrayIndex);
+        public override int Count => currentlySwitchedCollection.Count();
+        public override bool Contains(T item) => currentlySwitchedCollection.Contains(item);
+        public override void CopyTo(T[] array, int arrayIndex) => currentlySwitchedCollection.ToList().CopyTo(array, arrayIndex);
 
-        public override IEnumerator<T> GetEnumerator() => currentlySwichtedCollection.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => currentlySwichtedCollection.GetEnumerator();
+        public override IEnumerator<T> GetEnumerator() => currentlySwitchedCollection.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => currentlySwitchedCollection.GetEnumerator();
         #endregion
     }
 
@@ -147,7 +147,7 @@ namespace Petrroll.Helpers
             else if (oldNumberOfItems > numberOfFilteredItems)
             {
                 #if DEBUG
-                Console.WriteLine($"DC:Added:{sender}"); 
+                Console.WriteLine($"DC:Added:{sender}");
                 #endif
                 var changeIndex = BaseCollection.Take(BaseCollection.IndexOf(sender)).Count(Predicate);
                 RaiseCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, sender, changeIndex));

--- a/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
+++ b/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Petrroll.Helpers;
 using PowerSwitcher.TrayApp.Services;
 using System;
+using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace PowerSwitcher.TrayApp.Configuration
@@ -18,12 +19,15 @@ namespace PowerSwitcher.TrayApp.Configuration
         //TODO: Fix so that it can be changed during runtime
         public Key ShowOnShortcutKey { get; set; } = Key.L;
         public KeyModifier ShowOnShortcutKeyModifier { get; set; } = KeyModifier.Shift | KeyModifier.Win;
-
         bool showOnShortcutSwitch = false;
         public bool ShowOnShortcutSwitch { get { return showOnShortcutSwitch; } set { showOnShortcutSwitch = value; RaisePropertyChangedEvent(nameof(ShowOnShortcutSwitch)); } }
 
+        public Key CycleNextSchemaKey { get; set; } = Key.N;
+        public KeyModifier CycleNextSchemaKeyModifier { get; set; } = KeyModifier.Shift | KeyModifier.Win;
+        bool cycleNextSchemaSwitch = false;
+        public bool CycleNextSchemaSwitch { get { return cycleNextSchemaSwitch; } set { cycleNextSchemaSwitch = value; RaisePropertyChangedEvent(nameof(CycleNextSchemaSwitch)); } }
+
         bool showOnlyDefaultSchemas = false;
         public bool ShowOnlyDefaultSchemas { get { return showOnlyDefaultSchemas; } set { showOnlyDefaultSchemas = value; RaisePropertyChangedEvent(nameof(ShowOnlyDefaultSchemas)); } }
-
     }
 }

--- a/PowerSwitcher.TrayApp/MainWindow.xaml.cs
+++ b/PowerSwitcher.TrayApp/MainWindow.xaml.cs
@@ -1,19 +1,10 @@
 ﻿using PowerSwitcher.TrayApp.Extensions;
 using PowerSwitcher.TrayApp.Services;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+
 
 namespace PowerSwitcher.TrayApp
 {

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace PowerSwitcher.TrayApp.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AppStrings {
@@ -169,11 +169,20 @@ namespace PowerSwitcher.TrayApp.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable shortcut for cycling next schema.
+        /// </summary>
+        internal static string ToggleCycleNextSchemaSwitch {
+            get {
+                return ResourceManager.GetString("ToggleCycleNextSchemaSwitch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable shortcut for flyout toggle.
         /// </summary>
-        internal static string ToggleOnShowrtcutSwitch {
+        internal static string ToggleOnShortcutSwitch {
             get {
-                return ResourceManager.GetString("ToggleOnShowrtcutSwitch", resourceCulture);
+                return ResourceManager.GetString("ToggleOnShortcutSwitch", resourceCulture);
             }
         }
     }

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.resx
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -153,7 +153,10 @@
   <data name="ShowOnlyDefaultSchemas" xml:space="preserve">
     <value>Show only default power schemas</value>
   </data>
-  <data name="ToggleOnShowrtcutSwitch" xml:space="preserve">
+  <data name="ToggleOnShortcutSwitch" xml:space="preserve">
     <value>Enable shortcut for flyout toggle</value>
+  </data>
+  <data name="ToggleCycleNextSchemaSwitch" xml:space="preserve">
+    <value>Enable shortcut for cycling next schema</value>
   </data>
 </root>

--- a/PowerSwitcher.TrayApp/Services/GlobalShortcutService.cs
+++ b/PowerSwitcher.TrayApp/Services/GlobalShortcutService.cs
@@ -20,7 +20,7 @@ namespace PowerSwitcher.TrayApp.Services
         public event Action HotKeyFired;
 
         public int VirtualKeyCode => KeyInterop.VirtualKeyFromKey(Key);
-        public int Id =>  VirtualKeyCode + ((int)KeyModifiers* 0x10000); 
+        public int Id =>  VirtualKeyCode + ((int)KeyModifiers* 0x10000);
 
         public HotKey(Key k, KeyModifier keyModifiers)
         {
@@ -72,10 +72,10 @@ namespace PowerSwitcher.TrayApp.Services
         {
             if (!_dictHotKeyToCalBackProc.ContainsKey(hotkey.Id)) { throw new InvalidOperationException($"Trying to unregister not-registred Hotkey {hotkey.Id}"); }
 
-            var success = UnregisterHotKey(IntPtr.Zero, hotkey.Id); 
+            var success = UnregisterHotKey(IntPtr.Zero, hotkey.Id);
             if (!success) { throw new PowerSwitcherWrappersException($"UnregisterHotKey() failed|{Marshal.GetLastWin32Error()}"); }
 
-            _dictHotKeyToCalBackProc.Remove(hotkey.Id);          
+            _dictHotKeyToCalBackProc.Remove(hotkey.Id);
         }
 
         public const int WmHotKey = 0x0312;

--- a/PowerSwitcher.TrayApp/TrayApp.cs
+++ b/PowerSwitcher.TrayApp/TrayApp.cs
@@ -74,10 +74,15 @@ namespace PowerSwitcher.TrayApp
             onlyDefaultSchemasItem.Checked = configuration.Data.ShowOnlyDefaultSchemas;
             onlyDefaultSchemasItem.Click += OnlyDefaultSchemas_Click;
 
-            var enableShortcutsToggleItem = contextMenuSettings.MenuItems.Add($"{AppStrings.ToggleOnShowrtcutSwitch} ({configuration.Data.ShowOnShortcutKeyModifier} + {configuration.Data.ShowOnShortcutKey})");
+            var enableShortcutsToggleItem = contextMenuSettings.MenuItems.Add($"{AppStrings.ToggleOnShortcutSwitch} ({configuration.Data.ShowOnShortcutKeyModifier} + {configuration.Data.ShowOnShortcutKey})");
             enableShortcutsToggleItem.Enabled = !(Application.Current as App).HotKeyFailed;
             enableShortcutsToggleItem.Checked = configuration.Data.ShowOnShortcutSwitch;
             enableShortcutsToggleItem.Click += EnableShortcutsToggleItem_Click;
+
+            var enableCycleNextToggleItem = contextMenuSettings.MenuItems.Add($"{AppStrings.ToggleCycleNextSchemaSwitch} ({configuration.Data.CycleNextSchemaKeyModifier} + {configuration.Data.CycleNextSchemaKey})");
+            enableCycleNextToggleItem.Enabled = !(Application.Current as App).HotKeyFailed;
+            enableCycleNextToggleItem.Checked = configuration.Data.CycleNextSchemaSwitch;
+            enableCycleNextToggleItem.Click += EnableCycleNextToggleItem_Click;
 
             var aboutItem = contextMenuRootItems.Add($"{AppStrings.About} ({Assembly.GetEntryAssembly().GetName().Version})");
             aboutItem.Click += About_Click;
@@ -110,6 +115,18 @@ namespace PowerSwitcher.TrayApp
 
             configuration.Save();
         }
+
+        private void EnableCycleNextToggleItem_Click(object sender, EventArgs e)
+        {
+            WF.MenuItem enableCycleNextToggleItem = (WF.MenuItem)sender;
+
+            configuration.Data.CycleNextSchemaSwitch = !configuration.Data.CycleNextSchemaSwitch;
+            enableCycleNextToggleItem.Checked = configuration.Data.CycleNextSchemaSwitch;
+            enableCycleNextToggleItem.Enabled = !(Application.Current as App).HotKeyFailed;
+
+            configuration.Save();
+        }
+
 
         private void AutomaticHideItem_Click(object sender, EventArgs e)
         {

--- a/PowerSwitcher/PowerManager.cs
+++ b/PowerSwitcher/PowerManager.cs
@@ -20,6 +20,8 @@ namespace PowerSwitcher
 
         void SetPowerSchema(IPowerSchema schema);
         void SetPowerSchema(Guid guid);
+
+        void CycleNextPowerSchema();
     }
 
     public class PowerManager : ObservableObject, IPowerManager
@@ -53,10 +55,10 @@ namespace PowerSwitcher
             {
                 var originalSchema = Schemas.FirstOrDefault(sch => sch.Guid == newSchema.Guid);
                 if (originalSchema == null) { insertNewSchema(newSchemas, newSchema); originalSchema = newSchema; }
-               
+
                 if (newSchema.Guid == currSchemaGuid && originalSchema?.IsActive != true)
                 { setNewCurrSchema(originalSchema); }
-                
+
                 if (originalSchema?.Name != newSchema.Name)
                 { ((PowerSchema)originalSchema).Name = newSchema.Name; }
             }
@@ -125,8 +127,20 @@ namespace PowerSwitcher
             RaisePropertyChangedEvent(nameof(CurrentPowerStatus));
         }
 
+        public void CycleNextPowerSchema()
+        {
+            var nextSchemaIndex = (Schemas.IndexOf(CurrentSchema) + 1);
+            if ((nextSchemaIndex + 1) > Schemas.Count)
+                nextSchemaIndex = 0;
+
+            var nextPowerSchema = Schemas[nextSchemaIndex];
+
+            SetPowerSchema(nextPowerSchema);
+        }
+
+
         #region IDisposable Support
-        private bool disposedValue = false; 
+        private bool disposedValue = false;
 
         protected virtual void Dispose(bool disposing)
         {
@@ -143,8 +157,8 @@ namespace PowerSwitcher
         {
             Dispose(true);
 
-            //No destructor so isn't required (yet)            
-            // GC.SuppressFinalize(this); 
+            //No destructor so isn't required (yet)
+            // GC.SuppressFinalize(this);
         }
 
         #endregion


### PR DESCRIPTION
- Refactored variables to fix typos
- Added function to PowerManager to cycle to the next power schema
- Added Configuration variables for the Cycle to the next schema hotkey toggle and status
- Added app string to explain the setting
- Added business logic to register and unregister the hotkey when enabled or disabled
- Added business logic to register and unregister the hotkey from the xml config file
- Added business logic to fire cycling to the next power schema on hotkey press
- Removed unneeded whitespace in the code
- Removed unused "using" statements