### PR TITLE
feat: added schema switching on user inactivity

### DIFF
--- a/Petrroll.Helpers/Petrroll.Helpers.csproj
+++ b/Petrroll.Helpers/Petrroll.Helpers.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Petrroll.Helpers</RootNamespace>
     <AssemblyName>Petrroll.Helpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/PowerSwitcher.TrayApp/App.config
+++ b/PowerSwitcher.TrayApp/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/PowerSwitcher.TrayApp/App.xaml.cs
+++ b/PowerSwitcher.TrayApp/App.xaml.cs
@@ -4,6 +4,7 @@ using PowerSwitcher.TrayApp.Services;
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Windows;
@@ -21,6 +22,7 @@ namespace PowerSwitcher.TrayApp
         public IPowerManager PowerManager { get; private set; }
         public TrayApp TrayApp { get; private set; }
         public ConfigurationInstance<PowerSwitcherSettings> Configuration { get; private set; }
+        public InactivityWatcherService InactivityWatcher { get; private set; }
 
         private Mutex _mMutex;
         private void Application_Startup(object sender, StartupEventArgs e)
@@ -40,7 +42,26 @@ namespace PowerSwitcher.TrayApp
 
             PowerManager = new PowerManager();
             MainWindow = new MainWindow();
-            TrayApp = new TrayApp(PowerManager, Configuration); //Has to be last because it hooks to MainWindow
+
+            InactivityWatcher = new InactivityWatcherService(PowerManager);
+
+            if (Configuration.Data.InactivitySwitchEnabled)
+            {
+                var guidValid = PowerManager.Schemas.Any(s => s.Guid == Configuration.Data.InactivityPlanGuid);
+                if (guidValid)
+                {
+                    InactivityWatcher.Configure(true, Configuration.Data.InactivityPlanGuid, TimeSpan.FromSeconds(Configuration.Data.InactivityTimeoutSeconds));
+                }
+                else
+                {
+                    Configuration.Data.InactivitySwitchEnabled = false;
+                    Configuration.Data.InactivityPlanGuid = Guid.Empty;
+                    Configuration.Data.InactivityTimeoutSeconds = 0;
+                    Configuration.Save();
+                }
+            }
+
+            TrayApp = new TrayApp(PowerManager, Configuration, InactivityWatcher); //Has to be last because it hooks to MainWindow
 
             Configuration.Data.PropertyChanged += Configuration_PropertyChanged;
             if (Configuration.Data.ShowOnShortcutSwitch) { registerHotkeyFromConfiguration(); }
@@ -110,6 +131,7 @@ namespace PowerSwitcher.TrayApp
         private void App_OnExit(object sender, ExitEventArgs e)
         {
             DisposeMutex();
+            InactivityWatcher?.Dispose();
             PowerManager?.Dispose();
             HotKeyManager?.Dispose();
         }

--- a/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
+++ b/PowerSwitcher.TrayApp/Configuration/PowerSwitcherConfiguration.cs
@@ -5,6 +5,8 @@ using System.Windows.Input;
 
 namespace PowerSwitcher.TrayApp.Configuration
 {
+    public enum TrayIconColorTint { Green, Yellow, Red }
+
     [Serializable]
     public class PowerSwitcherSettings : ObservableObject
     {
@@ -24,6 +26,11 @@ namespace PowerSwitcher.TrayApp.Configuration
 
         bool showOnlyDefaultSchemas = false;
         public bool ShowOnlyDefaultSchemas { get { return showOnlyDefaultSchemas; } set { showOnlyDefaultSchemas = value; RaisePropertyChangedEvent(nameof(ShowOnlyDefaultSchemas)); } }
+
+        public bool InactivitySwitchEnabled { get; set; } = false;
+        public Guid InactivityPlanGuid { get; set; } = Guid.Empty;
+        public int InactivityTimeoutSeconds { get; set; } = TrayApp.InactivityTimeout180;
+        public TrayIconColorTint InactivityIconColorTint { get; set; } = TrayIconColorTint.Green;
 
     }
 }

--- a/PowerSwitcher.TrayApp/PowerSwitcher.TrayApp.csproj
+++ b/PowerSwitcher.TrayApp/PowerSwitcher.TrayApp.csproj
@@ -9,10 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PowerSwitcher.TrayApp</RootNamespace>
     <AssemblyName>PowerSwitcher.TrayApp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>latest</LangVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -23,10 +26,10 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationRevision>1</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -63,6 +66,18 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestCertificateThumbprint>C0925B3031C5728DBE532A9B74E7090489028E07</ManifestCertificateThumbprint>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ManifestKeyFile>PowerSwitcher.TrayApp_TemporaryKey.pfx</ManifestKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -106,6 +121,7 @@
       <DependentUpon>AppStrings.resx</DependentUpon>
     </Compile>
     <Compile Include="Services\GlobalShortcutService.cs" />
+    <Compile Include="Services\InactivityWatcherService.cs" />
     <Compile Include="ViewModels\MainWindowDesignViewModel.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
     <Compile Include="Services\AccentColorService.cs" />
@@ -139,8 +155,10 @@
     <EmbeddedResource Include="Resources\AppStrings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>AppStrings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.manifest" />
+    <None Include="PowerSwitcher.TrayApp_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/PowerSwitcher.TrayApp/Properties/AssemblyInfo.cs
+++ b/PowerSwitcher.TrayApp/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.4.0")]
-[assembly: AssemblyFileVersion("0.4.4.0")]
+[assembly: AssemblyVersion("0.4.5.1")]
+[assembly: AssemblyFileVersion("0.4.5.1")]

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace PowerSwitcher.TrayApp.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AppStrings {
@@ -88,7 +88,16 @@ namespace PowerSwitcher.TrayApp.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Automaticly change schema when on AC.
+        ///   Looks up a localized string similar to Automatically change schema when inactive.
+        /// </summary>
+        internal static string AutomaticallyChangeSchemaWhenInactive {
+            get {
+                return ResourceManager.GetString("AutomaticallyChangeSchemaWhenInactive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatically change schema when on AC.
         /// </summary>
         internal static string AutomaticOnOffACSwitch {
             get {
@@ -147,6 +156,15 @@ namespace PowerSwitcher.TrayApp.Resources {
         internal static string SchemaToSwitchOnAc {
             get {
                 return ResourceManager.GetString("SchemaToSwitchOnAc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Schema to switch to on inactivity.
+        /// </summary>
+        internal static string SchemaToSwitchOnInactivity {
+            get {
+                return ResourceManager.GetString("SchemaToSwitchOnInactivity", resourceCulture);
             }
         }
         

--- a/PowerSwitcher.TrayApp/Resources/AppStrings.resx
+++ b/PowerSwitcher.TrayApp/Resources/AppStrings.resx
@@ -127,7 +127,7 @@
     <value>PowerPlanSwitcher</value>
   </data>
   <data name="AutomaticOnOffACSwitch" xml:space="preserve">
-    <value>Automaticly change schema when on AC</value>
+    <value>Automatically change schema when on AC</value>
   </data>
   <data name="Exit" xml:space="preserve">
     <value>Exit</value>
@@ -143,6 +143,12 @@
   </data>
   <data name="SchemaToSwitchOffAc" xml:space="preserve">
     <value>Schema to switch to off AC</value>
+  </data>
+  <data name="AutomaticallyChangeSchemaWhenInactive" xml:space="preserve">
+    <value>Automatically change schema when inactive</value>
+  </data>
+  <data name="SchemaToSwitchOnInactivity" xml:space="preserve">
+    <value>Schema to switch to on inactivity</value>
   </data>
   <data name="SchemaToSwitchOnAc" xml:space="preserve">
     <value>Schema to switch to on AC</value>

--- a/PowerSwitcher.TrayApp/Services/InactivityWatcherService.cs
+++ b/PowerSwitcher.TrayApp/Services/InactivityWatcherService.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Timers;
+using System.Windows.Forms;
+using Application = System.Windows.Application;
+using Timer = System.Timers.Timer;
+
+namespace PowerSwitcher.TrayApp.Services;
+
+public class InactivityWatcherService(IPowerManager pwrManager) : IDisposable {
+    [DllImport("user32.dll")]
+    private static extern bool GetLastInputInfo(ref LastInputInfo plii);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LastInputInfo {
+        public uint cbSize;
+        public uint dwTime;
+    }
+
+    public event Action<bool> InactivityStateChanged;
+
+    private Timer timer;
+    private Guid schemaToRestore = Guid.Empty;
+    private bool inactivitySwitchFired;
+
+    private bool isEnabled;
+    private Guid inactivityPlanGuid = Guid.Empty;
+    private TimeSpan inactivityTimeout;
+
+    public void Configure(bool enabled, Guid planGuid, TimeSpan timeout) {
+        StopTimer();
+        if(inactivitySwitchFired) {
+            InactivityStateChanged?.Invoke(false);
+        }
+
+        inactivitySwitchFired = false;
+        schemaToRestore = Guid.Empty;
+
+        isEnabled = enabled;
+        inactivityPlanGuid = planGuid;
+        inactivityTimeout = timeout;
+
+        if(enabled && planGuid != Guid.Empty && inactivityTimeout > TimeSpan.Zero) {
+            StartTimer();
+        }
+    }
+
+    public void NotifyAcSwitchFired(Guid acAppropriateGuid) {
+        if(inactivitySwitchFired) {
+            schemaToRestore = acAppropriateGuid;
+        }
+    }
+
+    private void StartTimer() {
+        timer = new Timer(TimeSpan.FromSeconds(8).TotalMilliseconds);
+        timer.Elapsed += RunCheckForInactivity;
+        timer.AutoReset = true;
+        timer.Start();
+    }
+
+    private void StopTimer() {
+        if(timer == null) return;
+        timer.Stop();
+        timer.Dispose();
+        timer = null;
+    }
+
+    private void RunCheckForInactivity(object sender, ElapsedEventArgs e) {
+        Debug.WriteLine("Checking for inactivity");
+        Application.Current?.Dispatcher?.BeginInvoke(new Action(CheckInactivity));
+    }
+
+    private void CheckInactivity() {
+        if(!isEnabled || inactivityPlanGuid == Guid.Empty || inactivityTimeout <= TimeSpan.Zero) {
+            Debug.WriteLine("Check skipped");
+            return;
+        }
+
+        var idleMs = GetIdleTime();
+
+        Debug.WriteLine("Idle for: {0}", idleMs);
+
+        if(!inactivitySwitchFired) {
+            // FR-08: Switch to inactivity schema when idle long enough
+            if(idleMs >= inactivityTimeout) {
+                var currentGuid = pwrManager.CurrentSchema?.Guid ?? Guid.Empty;
+                Debug.WriteLine("Inactivity detected, switching to schema \"{0}\" from \"{1}\"", inactivityPlanGuid, currentGuid);
+
+                // FR-10: Don't switch if inactivity schema is already active
+                if(currentGuid != Guid.Empty && currentGuid != inactivityPlanGuid) {
+                    schemaToRestore = currentGuid;
+                    pwrManager.SetPowerSchema(inactivityPlanGuid);
+                    inactivitySwitchFired = true;
+                    InactivityStateChanged?.Invoke(true);
+                } else {
+                    Debug.WriteLine("Inactivity schema is already active, skipped");
+                }
+            }
+        } else {
+            // FR-09: Restore previous schema when activity is detected
+            if(idleMs < inactivityTimeout) {
+                Debug.WriteLine("Inactivity cancelled, restoring the original schema: " + schemaToRestore);
+
+                if(schemaToRestore != Guid.Empty) {
+                    pwrManager.SetPowerSchema(schemaToRestore);
+                }
+
+                schemaToRestore = Guid.Empty;
+                inactivitySwitchFired = false;
+                InactivityStateChanged?.Invoke(false);
+            }
+        }
+    }
+
+    private static TimeSpan GetIdleTime() {
+        var info = new LastInputInfo();
+        info.cbSize = (uint)Marshal.SizeOf(info);
+        GetLastInputInfo(ref info);
+
+        return TimeSpan.FromMilliseconds(unchecked((uint)Environment.TickCount - info.dwTime));
+    }
+
+    public void Dispose() => StopTimer();
+}

--- a/PowerSwitcher.TrayApp/TrayApp.cs
+++ b/PowerSwitcher.TrayApp/TrayApp.cs
@@ -1,6 +1,7 @@
 ﻿using Petrroll.Helpers;
 using PowerSwitcher.TrayApp.Configuration;
 using PowerSwitcher.TrayApp.Resources;
+using PowerSwitcher.TrayApp.Services;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -20,22 +21,33 @@ namespace PowerSwitcher.TrayApp
         public event Action ShowFlyout;
         IPowerManager pwrManager;
         ConfigurationInstance<PowerSwitcherSettings> configuration;
+        InactivityWatcherService inactivityWatcher;
+        System.Drawing.Icon defaultIcon;
+        System.Drawing.Icon inactiveIcon;
+
         #endregion
+        
+        internal const int InactivityTimeout180 = 180;
 
         #region Contructor
-        public TrayApp(IPowerManager powerManager, ConfigurationInstance<PowerSwitcherSettings> config)
+        public TrayApp(IPowerManager powerManager, ConfigurationInstance<PowerSwitcherSettings> config, InactivityWatcherService inactivityWatcherService)
         {
             this.pwrManager = powerManager;
             pwrManager.PropertyChanged += PwrManager_PropertyChanged;
+            inactivityWatcher = inactivityWatcherService;
 
             configuration = config;
 
             _trayIcon = new WF.NotifyIcon();
             _trayIcon.MouseClick += TrayIcon_MouseClick;
 
-            _trayIcon.Icon = new System.Drawing.Icon(Application.GetResourceStream(new Uri("pack://application:,,,/PowerSwitcher.TrayApp;component/Tray.ico")).Stream, WF.SystemInformation.SmallIconSize);
+            defaultIcon = new System.Drawing.Icon(Application.GetResourceStream(new Uri("pack://application:,,,/PowerSwitcher.TrayApp;component/Tray.ico")).Stream, WF.SystemInformation.SmallIconSize);
+            inactiveIcon = CreateInactivityIcon(defaultIcon, configuration.Data.InactivityIconColorTint);
+            _trayIcon.Icon = defaultIcon;
             _trayIcon.Text = string.Concat(AppStrings.AppName);
             _trayIcon.Visible = true;
+
+            inactivityWatcher.InactivityStateChanged += isInactive => _trayIcon.Icon = isInactive ? inactiveIcon : defaultIcon;
 
             this.ShowFlyout += (((App)Application.Current).MainWindow as MainWindow).ToggleWindowVisibility;
 
@@ -61,10 +73,45 @@ namespace PowerSwitcher.TrayApp
 
             var settingsOffACItem = contextMenuSettings.MenuItems.Add(AppStrings.SchemaToSwitchOffAc);
             settingsOffACItem.Name = "settingsOffAC";
+            
+            #region Inactivity configuration
+
+            var settingsInactivityItem = contextMenuSettings.MenuItems.Add(AppStrings.SchemaToSwitchOnInactivity);
+            settingsInactivityItem.Name = "settingsInactivity";
+
+            #endregion
 
             var automaticSwitchItem = contextMenuSettings.MenuItems.Add(AppStrings.AutomaticOnOffACSwitch);
             automaticSwitchItem.Checked = configuration.Data.AutomaticOnACSwitch;
             automaticSwitchItem.Click += AutomaticSwitchItem_Click;
+
+            #region Inactivity configuration
+
+            var settingsInactivityIntervalItem = contextMenuSettings.MenuItems.Add(AppStrings.AutomaticallyChangeSchemaWhenInactive);
+            settingsInactivityIntervalItem.Name = "settingsInactivityInterval";
+
+            var disabledItem = new WF.MenuItem("Disabled");
+            disabledItem.Name = "inactivityIntervalDisabled";
+            disabledItem.Click += InactivityDisabled_Click;
+            settingsInactivityIntervalItem.MenuItems.Add(disabledItem);
+
+            var intervalOptions = new[] {
+                (seconds: 15,  label: "After 15 seconds"),
+                (seconds: 60,  label: "After 1 minute"),
+                (seconds: InactivityTimeout180, label: "After 3 minutes"),
+                (seconds: 900, label: "After 15 minutes"),
+            };
+
+            foreach (var (seconds, label) in intervalOptions)
+            {
+                var intervalItem = new WF.MenuItem(label);
+                intervalItem.Name = $"inactivityAfter{seconds}";
+                var capturedSeconds = seconds;
+                intervalItem.Click += (s, ea) => setInactivityTimeout(capturedSeconds);
+                settingsInactivityIntervalItem.MenuItems.Add(intervalItem);
+            }
+
+            #endregion
 
             var automaticHideItem = contextMenuSettings.MenuItems.Add(AppStrings.HideFlyoutAfterSchemaChangeSwitch);
             automaticHideItem.Checked = configuration.Data.AutomaticFlyoutHideAfterClick;
@@ -175,6 +222,9 @@ namespace PowerSwitcher.TrayApp
             if(schemaToSwitchTo == null) { return; }
 
             pwrManager.SetPowerSchema(schemaToSwitchTo);
+
+            // FR-14: If user is idle and inactivity switch has fired, update restore target
+            inactivityWatcher?.NotifyAcSwitchFired(schemaGuidToSwitch);
         }
 
         #endregion
@@ -186,9 +236,33 @@ namespace PowerSwitcher.TrayApp
             clearPowerSchemasInTray();
 
             pwrManager.UpdateSchemas();
+
+            // FR-09: Validate saved inactivity GUID; disable gracefully if plan no longer exists
+            if (configuration.Data.InactivitySwitchEnabled)
+            {
+                var savedGuid = configuration.Data.InactivityPlanGuid;
+                if (!pwrManager.Schemas.Any(s => s.Guid == savedGuid))
+                {
+                    configuration.Data.InactivitySwitchEnabled = false;
+                    configuration.Data.InactivityPlanGuid = Guid.Empty;
+                    configuration.Data.InactivityTimeoutSeconds = 0;
+                    configuration.Save();
+                    inactivityWatcher.Configure(false, Guid.Empty, TimeSpan.Zero);
+                }
+            }
+
             foreach (var powerSchema in pwrManager.Schemas)
             {
                 updateTrayMenuWithPowerSchema(powerSchema);
+            }
+
+            var intervalMenu = _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsInactivityInterval"];
+            var intervalActive = configuration.Data.InactivitySwitchEnabled && configuration.Data.InactivityTimeoutSeconds > 0;
+            intervalMenu.Text = AppStrings.AutomaticallyChangeSchemaWhenInactive;
+            foreach (WF.MenuItem item in intervalMenu.MenuItems) {
+                item.Checked = item.Name == "inactivityIntervalDisabled" 
+                    ? !intervalActive 
+                    : intervalActive && configuration.Data.InactivityTimeoutSeconds == int.Parse(item.Name.Substring("inactivityAfter".Length));
             }
         }
 
@@ -215,6 +289,18 @@ namespace PowerSwitcher.TrayApp
                 );
 
             _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsOnAC"].MenuItems.Add(0, newItemSettingsOnAC);
+
+            updateInactivityMenuWithPowerSchema(powerSchema);
+        }
+
+        private void updateInactivityMenuWithPowerSchema(IPowerSchema powerSchema)
+        {
+            var schemaItem = new WF.MenuItem(powerSchema.Name);
+            schemaItem.Name = $"inactivityScheme{powerSchema.Guid}";
+            schemaItem.Checked = configuration.Data.InactivityPlanGuid == powerSchema.Guid;
+            schemaItem.Click += (s, ea) => setInactivityPlan(powerSchema);
+
+            _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsInactivity"].MenuItems.Add(schemaItem);
         }
 
         private void clearPowerSchemasInTray()
@@ -230,6 +316,7 @@ namespace PowerSwitcher.TrayApp
 
             _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsOffAC"].MenuItems.Clear();
             _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsOnAC"].MenuItems.Clear();
+            _trayIcon.ContextMenu.MenuItems["settings"].MenuItems["settingsInactivity"].MenuItems.Clear();
         }
 
         private WF.MenuItem getNewPowerSchemaItem(IPowerSchema powerSchema, EventHandler clickedHandler, bool isChecked)
@@ -261,6 +348,78 @@ namespace PowerSwitcher.TrayApp
         {
             pwrManager.SetPowerSchema(powerSchema);
         }
+
+        private void setInactivityPlan(IPowerSchema schema)
+        {
+            configuration.Data.InactivityPlanGuid = schema.Guid;
+            configuration.Save();
+            inactivityWatcher.Configure(configuration.Data.InactivitySwitchEnabled, schema.Guid, TimeSpan.FromSeconds(configuration.Data.InactivityTimeoutSeconds));
+        }
+
+        private void InactivityDisabled_Click(object sender, EventArgs e)
+        {
+            configuration.Data.InactivitySwitchEnabled = false;
+            configuration.Data.InactivityTimeoutSeconds = 0;
+            configuration.Save();
+            inactivityWatcher.Configure(false, configuration.Data.InactivityPlanGuid, TimeSpan.Zero);
+        }
+
+        private void setInactivityTimeout(int seconds)
+        {
+            configuration.Data.InactivityTimeoutSeconds = seconds;
+            configuration.Data.InactivitySwitchEnabled = configuration.Data.InactivityPlanGuid != Guid.Empty;
+            configuration.Save();
+            inactivityWatcher.Configure(configuration.Data.InactivitySwitchEnabled, configuration.Data.InactivityPlanGuid, TimeSpan.FromSeconds(seconds));
+        }
+        #endregion
+
+        #region IconHelpers
+
+        private static System.Drawing.Icon CreateInactivityIcon(System.Drawing.Icon original, TrayIconColorTint colorTint) {
+            using var bmp = new System.Drawing.Bitmap(original.Width, original.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            using (var g = System.Drawing.Graphics.FromImage(bmp)) {
+                g.DrawIcon(original, 0, 0);
+            }
+
+            TintBitmap(bmp, colorTint);
+
+            var hicon = bmp.GetHicon();
+            var icon = (System.Drawing.Icon)System.Drawing.Icon.FromHandle(hicon).Clone();
+            DestroyIcon(hicon);
+            return icon;
+        }
+
+        private static void TintBitmap(System.Drawing.Bitmap bmp, TrayIconColorTint colorTint) {
+            var tint = colorTint switch {
+                TrayIconColorTint.Yellow => System.Drawing.Color.FromArgb(255, 255, 102),
+                TrayIconColorTint.Red => System.Drawing.Color.FromArgb(255, 102, 102),
+                _ => System.Drawing.Color.FromArgb(144, 238, 144) // Green
+            };
+
+            var rect = new System.Drawing.Rectangle(0, 0, bmp.Width, bmp.Height);
+            var data = bmp.LockBits(rect, System.Drawing.Imaging.ImageLockMode.ReadWrite,
+                System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            try {
+                var bytes = Math.Abs(data.Stride) * bmp.Height;
+                var pixels = new byte[bytes];
+                System.Runtime.InteropServices.Marshal.Copy(data.Scan0, pixels, 0, bytes);
+
+                for(var i = 0; i < bytes; i += 4) {
+                    if(pixels[i + 3] == 0) continue; // skip transparent
+                    pixels[i] = (byte)(pixels[i] * tint.B / 255); // B
+                    pixels[i + 1] = (byte)(pixels[i + 1] * tint.G / 255); // G
+                    pixels[i + 2] = (byte)(pixels[i + 2] * tint.R / 255); // R
+                }
+
+                System.Runtime.InteropServices.Marshal.Copy(pixels, 0, data.Scan0, bytes);
+            } finally {
+                bmp.UnlockBits(data);
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern bool DestroyIcon(IntPtr handle);
+
         #endregion
 
         #region OtherItemsClicked

--- a/PowerSwitcher/PowerSwitcher.csproj
+++ b/PowerSwitcher/PowerSwitcher.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PowerSwitcher</RootNamespace>
     <AssemblyName>PowerSwitcher</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Added an option to switch to a schema when the user is inactive, and restore the previous one when an activity is detected. 

This helps to reduce CPU power consumption by ~10-15% and turn off screens/HDDs early by switching to the "Power saver" schema, while maintaining full CPU performance when the user is in front of their PC.

I'm using it to reduce my workstation's power consumption when I'm temporarily away from the screen, as I have to run it on batteries/solar power due to grid outages caused by Russia's bombings of Ukraine.

Hope this is useful to someone too!

<img width="755" height="412" alt="image" src="https://github.com/user-attachments/assets/78ec3567-be2b-4cb5-acb5-33864edbc1be" />

<img width="770" height="424" alt="image" src="https://github.com/user-attachments/assets/8c4a0db2-14bf-4d69-ad2d-694053db5b0c" />
